### PR TITLE
Fix width preventing clickable area

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,11 +80,13 @@
                 <iframe src="https://ghbtns.com/github-btn.html?user=BrOrlandi&repo=StrangerThingsIntroCreator&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
             </div>
         </div>
-        <div class="footerText right">
+        <div class="footerText right intros">
           <a href="http://westworldintrocreator.kassellabs.io/" target="_blank"><img src="assets/wic.jpg" alt="Westworld Intro Creator" width="120" style="margin-bottom: 20px"/></a><br>
-            <a href="https://brorlandi.github.io/StarWarsIntroCreator/" target="_blank"><img src="assets/swic.jpg" alt="Star Wars Intro Creator" width="120" style="margin-bottom: 20px"/></a>
-            <a id="termsOfService" href="termsOfService.html">Terms of Service</a><br/>
-            <span style="line-height: 1.2">Developed by <a href="https://github.com/BrOrlandi" target="2">Bruno Orlandi</a> and <a href="https://github.com/nihey" target="2">Nihey Takizawa</a> based on <a href="http://wbobeirne.com/stranger-things/" target="2">William O'Beirne</a> work.</span>
+          <a href="https://brorlandi.github.io/StarWarsIntroCreator/" target="_blank"><img src="assets/swic.jpg" alt="Star Wars Intro Creator" width="120" style="margin-bottom: 20px"/></a>
+          <a id="termsOfService" href="termsOfService.html">Terms of Service</a><br/>
+        </div>
+        <div class="footerText right developers">
+          <span style="line-height: 1.2">Developed by <a href="https://github.com/BrOrlandi" target="2">Bruno Orlandi</a> and <a href="https://github.com/nihey" target="2">Nihey Takizawa</a> based on <a href="http://wbobeirne.com/stranger-things/" target="2">William O'Beirne</a> work.</span>
         </div>
     </div>
     <div id="StrangerIntro" class="hide">

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -229,8 +229,6 @@ body.overflow{
     font-family: "Avant Garde", Avantgarde, "Century Gothic", CenturyGothic, sans-serif;
     color: $color-title;
     bottom: 10px;
-    width: 550px;
-    max-width: 30%;
     font-size: 0.9em;
 
     &#btcether {
@@ -246,10 +244,19 @@ body.overflow{
         }
     }
 
-    &.right{
+    &.right {
         position: fixed;
         right: 10px;
         text-align: right;
+    }
+
+    &.intros {
+        margin-bottom: 51px;
+    }
+
+    &.developers {
+        max-width: 30%;
+        width: 550px;
     }
 
     a{


### PR DESCRIPTION
The element of Bitcoin & Ether was resulting in a wide width, preventing the user to click on Play, as well as the developers element from clicking the last fields of the form.

The fix should not change visible structure to the user, only the clickable area.

![image](https://user-images.githubusercontent.com/6919329/38772964-00dd03c2-4019-11e8-824a-e363b0c95348.png)